### PR TITLE
Fix navigation icon, translate blog text, and improve mobile menu readability

### DIFF
--- a/src/components/blog/Pagination.astro
+++ b/src/components/blog/Pagination.astro
@@ -10,7 +10,12 @@ export interface Props {
   nextText?: string;
 }
 
-const { prevUrl, nextUrl, prevText = "Newer posts", nextText = "Older posts" } = Astro.props;
+const {
+  prevUrl,
+  nextUrl,
+  prevText = "Entradas más recientes",
+  nextText = "Entradas anteriores",
+} = Astro.props;
 ---
 
 {

--- a/src/components/blog/RelatedPosts.astro
+++ b/src/components/blog/RelatedPosts.astro
@@ -18,9 +18,9 @@ const relatedPosts = post.tags ? await getRelatedPosts(post, 4) : [];
   APP_BLOG.isRelatedPostsEnabled && relatedPosts.length ? (
     <section class="mx-auto max-w-5xl px-4 py-10 md:py-14">
       <div class="mb-6 flex items-baseline justify-between">
-        <h2 class="text-2xl font-bold text-brand-900 md:text-3xl">Related Posts</h2>
+        <h2 class="text-2xl font-bold text-brand-900 md:text-3xl">Publicaciones relacionadas</h2>
         <a href={getBlogPermalink()} class="btn text-sm">
-          View All Posts
+          Ver todas las entradas
         </a>
       </div>
       <ul class="grid gap-4 sm:grid-cols-2">

--- a/src/components/blog/SinglePost.astro
+++ b/src/components/blog/SinglePost.astro
@@ -62,7 +62,7 @@ const image = await findImage(post.image);
           {
             post.readingTime && (
               <>
-                &nbsp;· <span>{post.readingTime}</span> min read
+                &nbsp;· <span>{post.readingTime}</span> min de lectura
               </>
             )
           }

--- a/src/components/blog/ToBlogLink.astro
+++ b/src/components/blog/ToBlogLink.astro
@@ -15,6 +15,6 @@ const { textDirection } = I18N;
       ) : (
         <Icon name="tabler:chevron-left" class="-ml-1.5 mr-1 h-5 w-5 rtl:-mr-1.5 rtl:ml-1" />
       )
-    } Back to Blog
+    } Volver al blog
   </Button>
 </div>

--- a/src/components/common/SocialShare.astro
+++ b/src/components/common/SocialShare.astro
@@ -11,10 +11,10 @@ const { text, url, class: className = "inline-block" } = Astro.props;
 ---
 
 <div class={className}>
-  <span class="align-super font-bold text-slate-500 dark:text-slate-400">Share:</span>
+  <span class="align-super font-bold text-slate-500 dark:text-slate-400">Comparte:</span>
   <button
     class="ml-2 rtl:ml-0 rtl:mr-2"
-    title="Twitter Share"
+    title="Compartir en Twitter"
     data-aw-social-share="twitter"
     data-aw-url={url}
     data-aw-text={text}
@@ -25,7 +25,7 @@ const { text, url, class: className = "inline-block" } = Astro.props;
   </button>
   <button
     class="ml-2 rtl:ml-0 rtl:mr-2"
-    title="Facebook Share"
+    title="Compartir en Facebook"
     data-aw-social-share="facebook"
     data-aw-url={url}
     ><Icon
@@ -35,7 +35,7 @@ const { text, url, class: className = "inline-block" } = Astro.props;
   </button>
   <button
     class="ml-2 rtl:ml-0 rtl:mr-2"
-    title="Linkedin Share"
+    title="Compartir en LinkedIn"
     data-aw-social-share="linkedin"
     data-aw-url={url}
     data-aw-text={text}
@@ -46,7 +46,7 @@ const { text, url, class: className = "inline-block" } = Astro.props;
   </button>
   <button
     class="ml-2 rtl:ml-0 rtl:mr-2"
-    title="Whatsapp Share"
+    title="Compartir en WhatsApp"
     data-aw-social-share="whatsapp"
     data-aw-url={url}
     data-aw-text={text}
@@ -57,7 +57,7 @@ const { text, url, class: className = "inline-block" } = Astro.props;
   </button>
   <button
     class="ml-2 rtl:ml-0 rtl:mr-2"
-    title="Email Share"
+    title="Compartir por correo"
     data-aw-social-share="mail"
     data-aw-url={url}
     data-aw-text={text}

--- a/src/components/common/ToggleMenu.astro
+++ b/src/components/common/ToggleMenu.astro
@@ -5,7 +5,7 @@ export interface Props {
 }
 
 const {
-  label = "Toggle Menu",
+  label = "Abrir menú",
   class:
     className = "flex flex-col h-12 w-12 rounded justify-center items-center cursor-pointer group",
 } = Astro.props;

--- a/src/components/widgets/Header.astro
+++ b/src/components/widgets/Header.astro
@@ -66,47 +66,53 @@ const {
       </div>
     </div>
     <nav
-      class="hidden items-center overflow-visible md:mx-5 md:flex md:w-auto md:justify-self-center"
+      class="hidden w-full overflow-visible md:mx-5 md:flex md:w-auto md:items-center md:justify-self-center"
       aria-label="Main navigation"
     >
-      <ul class="hidden items-center gap-5 whitespace-nowrap md:flex">
+      <ul
+        class="flex w-full flex-col gap-4 rounded-3xl bg-white/95 p-6 font-medium text-gray-800 shadow-lg dark:bg-slate-900/95 dark:text-slate-100 md:flex md:flex-row md:items-center md:gap-5 md:rounded-none md:bg-transparent md:p-0 md:shadow-none md:whitespace-nowrap mx-auto md:mx-0"
+      >
         <!-- Men�: Actividades -->
-        <li class="relative">
+        <li class="relative w-full md:w-auto">
           <details class="group">
             <summary
               tabindex="0"
               aria-haspopup="menu"
-              class="nav-dd focus-ring inline-flex cursor-pointer select-none items-center gap-1 whitespace-nowrap text-base text-gray-700 hover:text-brand-800 md:text-lg"
+              class="nav-dd focus-ring inline-flex w-full cursor-pointer select-none items-center justify-between gap-1 whitespace-nowrap text-lg text-gray-800 hover:text-brand-800 dark:text-slate-100 dark:hover:text-brand-200 md:w-auto md:justify-start"
             >
               Actividades
-              <span class="ml-0.5 inline-block transition-transform group-open:rotate-180">?</span>
+              <span
+                aria-hidden="true"
+                class="ml-0.5 inline-block transition-transform group-open:rotate-180"
+                >▾</span
+              >
             </summary>
             <div
               role="menu"
-              class="dropdown-panel absolute left-0 z-50 mt-2 w-56 rounded-xl border bg-white p-2 shadow-lg ring-1 ring-black/5"
+              class="dropdown-panel absolute left-0 z-50 mt-2 w-full rounded-xl border bg-white p-2 shadow-lg ring-1 ring-black/5 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 md:w-56"
             >
               <a
                 href="/#yoga"
                 role="menuitem"
-                class="focus-ring block rounded-lg px-3 py-2 text-[15px] hover:bg-brand-50 md:text-base"
+                class="focus-ring block rounded-lg px-3 py-2 text-[15px] text-gray-800 hover:bg-brand-50 dark:text-slate-100 dark:hover:bg-slate-800 md:text-base"
                 >Yoga</a
               >
               <a
                 href="/#banos"
                 role="menuitem"
-                class="focus-ring block rounded-lg px-3 py-2 text-[15px] hover:bg-brand-50 md:text-base"
+                class="focus-ring block rounded-lg px-3 py-2 text-[15px] text-gray-800 hover:bg-brand-50 dark:text-slate-100 dark:hover:bg-slate-800 md:text-base"
                 >Ba�os de Bosque</a
               >
               <a
                 href="/#pilates"
                 role="menuitem"
-                class="focus-ring block rounded-lg px-3 py-2 text-[15px] hover:bg-brand-50 md:text-base"
+                class="focus-ring block rounded-lg px-3 py-2 text-[15px] text-gray-800 hover:bg-brand-50 dark:text-slate-100 dark:hover:bg-slate-800 md:text-base"
                 >Pilates</a
               >
               <a
                 href="/#otras"
                 role="menuitem"
-                class="focus-ring block rounded-lg px-3 py-2 text-[15px] hover:bg-brand-50 md:text-base"
+                class="focus-ring block rounded-lg px-3 py-2 text-[15px] text-gray-800 hover:bg-brand-50 dark:text-slate-100 dark:hover:bg-slate-800 md:text-base"
                 >Otras actividades</a
               >
             </div>
@@ -114,30 +120,34 @@ const {
         </li>
 
         <!-- Men�: Nuestra sala -->
-        <li class="relative">
+        <li class="relative w-full md:w-auto">
           <details class="group">
             <summary
               tabindex="0"
               aria-haspopup="menu"
-              class="nav-dd focus-ring inline-flex cursor-pointer select-none items-center gap-1 whitespace-nowrap text-base text-gray-700 hover:text-brand-800 md:text-lg"
+              class="nav-dd focus-ring inline-flex w-full cursor-pointer select-none items-center justify-between gap-1 whitespace-nowrap text-lg text-gray-800 hover:text-brand-800 dark:text-slate-100 dark:hover:text-brand-200 md:w-auto md:justify-start"
             >
               Nuestra sala
-              <span class="ml-0.5 inline-block transition-transform group-open:rotate-180">?</span>
+              <span
+                aria-hidden="true"
+                class="ml-0.5 inline-block transition-transform group-open:rotate-180"
+                >▾</span
+              >
             </summary>
             <div
               role="menu"
-              class="dropdown-panel absolute left-0 z-50 mt-2 w-56 rounded-xl border bg-white p-2 shadow-lg ring-1 ring-black/5"
+              class="dropdown-panel absolute left-0 z-50 mt-2 w-full rounded-xl border bg-white p-2 shadow-lg ring-1 ring-black/5 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 md:w-56"
             >
               <a
                 href="/#sala"
                 role="menuitem"
-                class="focus-ring block rounded-lg px-3 py-2 text-[15px] hover:bg-brand-50 md:text-base"
+                class="focus-ring block rounded-lg px-3 py-2 text-[15px] text-gray-800 hover:bg-brand-50 dark:text-slate-100 dark:hover:bg-slate-800 md:text-base"
                 >Nuestra sala</a
               >
               <a
                 href="/#horario"
                 role="menuitem"
-                class="focus-ring block rounded-lg px-3 py-2 text-[15px] hover:bg-brand-50 md:text-base"
+                class="focus-ring block rounded-lg px-3 py-2 text-[15px] text-gray-800 hover:bg-brand-50 dark:text-slate-100 dark:hover:bg-slate-800 md:text-base"
                 >Horario</a
               >
             </div>
@@ -148,21 +158,21 @@ const {
         <li>
           <a
             href="/#contacto"
-            class="focus-ring text-base text-gray-700 no-underline hover:text-brand-800 md:text-lg"
+            class="focus-ring block text-lg text-gray-800 no-underline hover:text-brand-800 dark:text-slate-100 dark:hover:text-brand-200 md:inline"
             >Contacto</a
           >
         </li>
         <li>
           <a
             href="/blog"
-            class="focus-ring text-base text-gray-700 no-underline hover:text-brand-800 md:text-lg"
+            class="focus-ring block text-lg text-gray-800 no-underline hover:text-brand-800 dark:text-slate-100 dark:hover:text-brand-200 md:inline"
             >Blog</a
           >
         </li>
 
         <!-- CTA (duplicado aqu� para mantener estructura; el real sigue a la derecha) -->
         <li class="md:hidden">
-          <a href="/socios" class="btn focus-ring no-underline">Comunidad</a>
+          <a href="/socios" class="btn focus-ring block w-full text-center no-underline">Comunidad</a>
         </li>
       </ul>
     </nav>

--- a/src/pages/[...blog]/[...page].astro
+++ b/src/pages/[...blog]/[...page].astro
@@ -24,7 +24,7 @@ const currentPage = page.currentPage ?? 1;
 // const allTags = await findTags();
 
 const metadata = {
-  title: `Blog${currentPage > 1 ? ` — Page ${currentPage}` : ""}`,
+  title: `Blog${currentPage > 1 ? ` — Página ${currentPage}` : ""}`,
   robots: {
     index: blogListRobots?.index && currentPage === 1,
     follow: blogListRobots?.follow,

--- a/src/pages/[...blog]/[category]/[...page].astro
+++ b/src/pages/[...blog]/[category]/[...page].astro
@@ -20,7 +20,7 @@ const { page, category } = Astro.props as Props;
 const currentPage = page.currentPage ?? 1;
 
 const metadata = {
-  title: `Category '${category.title}' ${currentPage > 1 ? ` — Page ${currentPage}` : ""}`,
+  title: `Categoría "${category.title}"${currentPage > 1 ? ` — Página ${currentPage}` : ""}`,
   robots: {
     index: blogCategoryRobots?.index,
     follow: blogCategoryRobots?.follow,

--- a/src/pages/[...blog]/[tag]/[...page].astro
+++ b/src/pages/[...blog]/[tag]/[...page].astro
@@ -20,7 +20,7 @@ const { page, tag } = Astro.props as Props;
 const currentPage = page.currentPage ?? 1;
 
 const metadata = {
-  title: `Posts by tag '${tag.title}'${currentPage > 1 ? ` — Page ${currentPage} ` : ""}`,
+  title: `Publicaciones por etiqueta "${tag.title}"${currentPage > 1 ? ` — Página ${currentPage}` : ""}`,
   robots: {
     index: blogTagRobots?.index,
     follow: blogTagRobots?.follow,
@@ -30,7 +30,7 @@ const metadata = {
 
 <Layout metadata={metadata}>
   <section class="mx-auto max-w-4xl px-4 py-12 sm:py-16 md:px-6 lg:py-20">
-    <Headline>Tag: {tag.title}</Headline>
+    <Headline>Etiqueta: {tag.title}</Headline>
     <BlogList posts={page.data} />
     <Pagination prevUrl={page.url.prev} nextUrl={page.url.next} />
   </section>

--- a/src/pages/[...socios]/[tag]/[...page].astro
+++ b/src/pages/[...socios]/[tag]/[...page].astro
@@ -20,13 +20,13 @@ const { page, tag } = Astro.props as Props;
 const currentPage = page.currentPage ?? 1;
 
 const metadata = {
-  title: `Posts por tag '${tag.title}'${currentPage > 1 ? ` · Página ${currentPage}` : ""}`,
+  title: `Publicaciones por etiqueta "${tag.title}"${currentPage > 1 ? ` · Página ${currentPage}` : ""}`,
 };
 ---
 
 <Layout metadata={metadata}>
   <section class="mx-auto max-w-4xl px-4 py-12 sm:py-16 md:px-6 lg:py-20">
-    <Headline>Tag: {tag.title}</Headline>
+    <Headline>Etiqueta: {tag.title}</Headline>
     <BlogList posts={page.data} />
     <Pagination prevUrl={page.url.prev} nextUrl={page.url.next} />
   </section>


### PR DESCRIPTION
## Summary
- restore a downward caret indicator in the header dropdown trigger
- localize blog and socios UI copy to Spanish, including pagination, sharing labels, and metadata titles
- enhance the mobile navigation layout with theme-aware colors, larger touch targets, and better dropdown styling

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c90fdef3788333a9260a5cad4b4661