### PR TITLE
Allow Google Maps iframe in CSP

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -5,7 +5,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: accelerometer=(), autoplay=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' https://www.instagram.com https://www.tiktok.com https://platform.twitter.com; style-src 'self' 'unsafe-inline'; font-src 'self' data: https:; connect-src 'self' https:; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com https://www.instagram.com https://www.tiktok.com https://platform.twitter.com https://w.soundcloud.com https://www.ivoox.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' https://www.instagram.com https://www.tiktok.com https://platform.twitter.com; style-src 'self' 'unsafe-inline'; font-src 'self' data: https:; connect-src 'self' https:; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com https://www.instagram.com https://www.tiktok.com https://platform.twitter.com https://w.soundcloud.com https://www.ivoox.com https://www.google.com https://maps.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
   X-XSS-Protection: 0
 
 # Cache agresiva para assets generados por Astro


### PR DESCRIPTION
## Summary
- allow Google Maps iframe domains in the Content Security Policy so the landing page map can render again

## Testing
- CI=1 npm run check:prettier *(fails: existing files need formatting)*

------
https://chatgpt.com/codex/tasks/task_e_68c940941de883339a4709f728ddf31e